### PR TITLE
Update build.gradle and update to Minestom 1.18 branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
 }
 
-group 'eu.arctas'
+group 'com.epicgui'
 version '1.0-SNAPSHOT'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
 }
 
-group 'org.example'
+group 'eu.arctas'
 version '1.0-SNAPSHOT'
 
 repositories {
@@ -27,5 +27,13 @@ test {
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
-    id 'java'
+    id 'java-library'
+    id 'maven-publish'
+    id 'idea'
 }
 
 group 'org.example'
@@ -15,7 +17,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 
-    implementation 'com.github.Minestom:Minestom:cca614fea8'
+    implementation 'com.github.Minestom:Minestom:1a604b7b91'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/com/epicgui/test/MainTest.java
+++ b/src/test/java/com/epicgui/test/MainTest.java
@@ -83,10 +83,7 @@ public class MainTest {
                 }
             }
         }
-        @Override
-        public void fillBiomes(Biome[] biomes, int chunkX, int chunkZ) {
-            Arrays.fill(biomes, Biome.PLAINS);
-        }
+
         @Override
         public List<ChunkPopulator> getPopulators() {
             return null;


### PR DESCRIPTION
This PR just updates the build.gradle (adds the maven publication block) so that it finally works with JitPack, and it updates to the Minestom 1.18 branch.